### PR TITLE
[DOCS-9857] Minor copy edits for the OC CasC files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+#Ignore auto-generated files and directories
+.DS_Store
+.idea
+.vscode
+*.bkp
+*.dtmp
+*.save

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 CloudBees
+Copyright (c) 2024 CloudBees, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![gitleaks badge](https://img.shields.io/badge/protected%20by-gitleaks-blue)](https://github.com/zricethezav/gitleaks#pre-commit) [![gitsecrets](https://img.shields.io/badge/protected%20by-gitsecrets-blue)](https://github.com/awslabs/git-secrets)
 
-Repository for [Configuration as Code for the operations center](https://docs.cloudbees.com/docs/cloudbees-ci/latest/casc-oc/).
+This repository is for [Configuration as Code (CasC) for the operations center](https://docs.cloudbees.com/docs/cloudbees-ci/latest/casc-oc/).
 
-Plugins and plugin catalogs curated with [casc-plugin-dependency-calculation](https://github.com/kyounger/casc-plugin-dependency-calculation).
+Plugins are curated with the [CloudBees CasC Plugin Catalog and Transitive Dependencies Calculator](https://github.com/kyounger/casc-plugin-dependency-calculation).
 
-This bundle is tested and validated against `chart` version from `main.yaml` in [CloudBees CI Add-on for AWS EKS](https://github.com/cloudbees/terraform-aws-cloudbees-ci-eks-addon)
+This bundle is tested and validated against the `chart` version from the `main.yaml` in [CloudBees CI add-on for Amazon EKS blueprints](https://github.com/cloudbees/terraform-aws-cloudbees-ci-eks-addon).

--- a/bp02/items/items-root.yaml
+++ b/bp02/items/items-root.yaml
@@ -11,7 +11,7 @@ items:
         cpus: 1.0
         disk: 20
         storageClassName: "gp3"
-  # CasC, Non-HA
+  # CasC, non-HA
   - kind: managedController
     name: team-b
     configuration:

--- a/bp02/items/items-root.yaml
+++ b/bp02/items/items-root.yaml
@@ -2,7 +2,7 @@ removeStrategy:
   rbac: SYNC
   items: NONE
 items:
-  # Non-Casc
+  # Non-CasC
   - kind: managedController
     name: team-a
     configuration:
@@ -11,7 +11,7 @@ items:
         cpus: 1.0
         disk: 20
         storageClassName: "gp3"
-  # Casc, Non-HA
+  # CasC, Non-HA
   - kind: managedController
     name: team-b
     configuration:
@@ -41,7 +41,7 @@ items:
     properties:
       - configurationAsCode:
           bundle: "main/bp02.none-ha"
-  # Casc, HA
+  # CasC, HA
   - kind: managedController
     name: team-c-ha
     configuration:

--- a/bp02/jcasc/main.yaml
+++ b/bp02/jcasc/main.yaml
@@ -5,7 +5,7 @@ unclassified:
   bundleStorageService:
     activated: true
     activeBundle:
-      name: "casc-mm-store"
+      name: "casc-mc-store"
       retriever:
         SCM:
           defaultVersion: "main"


### PR DESCRIPTION
Minor copy edits for consistency with the recently revised CloudBees CI add-on for Amazon EKS blueprints.